### PR TITLE
Backport CVE-2021-20271 and CVE-2021-3421 fixes

### DIFF
--- a/Fix-CVE-2021-20271-and-CVE-2021-3421.patch
+++ b/Fix-CVE-2021-20271-and-CVE-2021-3421.patch
@@ -1,0 +1,188 @@
+From 52039cec6da816332d1c2292fa296ba3f286875b Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Mon, 15 Mar 2021 12:26:40 -0400
+Subject: [PATCH] Fix CVE-2021-20271 and CVE-2021-3421
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This fixes CVE-2021-20271 (“SigBug”) and CVE-2021-3421 (“DBCorrupt”).
+It is based on upstream commits d6a86b5e69e46cc283b1e06c92343319beb42e21
+and f7b97593af5cf818a5c6c5b9bc55bba6d08c9cb0.
+
+RPM packages contain a main header, which is signed, and a signature
+header, which is not.  When importing a package, RPM merges the two
+headers into a single data structure.  That merged header is what is
+imported into the database.  Since the signature header is not signed,
+it is not trusted, and so RPM needs to be extremely careful about what
+data it takes from it.
+
+Unfortunately, it wasn’t careful enough.  While obviously nasty tags
+(such as scriptlets) were not imported, there were other problems that
+could be exploited.
+
+SigBug is a signature verification bypass vulnerability.  If the main
+header contained a signature, RPM would not even parse it, much less
+check it for validity.  However, RPM *would* include it in merged
+headers, confusing clients of the librpm API.  In the case of DNF, this
+is enough to achieve full signature verification bypass, and thus
+arbitrary code execution.  Default CentOS and Fedora installations are
+vulnerable.  The latter requires the attacker to obtain a rogue TLS
+certificate, but the former does not.  libdnf was not vulnerable, as it
+enforces transaction-level signature verification.  Metadata signing
+also mitigates this vulnerability.
+
+DBCorrupt is a denial of service vulnerability.  Data merged into the
+main header was not properly validated, so when RPM re-read the header
+from the database, it would consider it to be corrupt.  This required a
+package reinstall to repair.  Transaction-level signature verification
+did *not* mitigate this vulnerability.  Only metadata signing did.
+---
+ lib/package.c | 109 ++++++++++++++++++++++++--------------------------
+ 1 file changed, 53 insertions(+), 56 deletions(-)
+
+diff --git a/lib/package.c b/lib/package.c
+index 081123d..8f66666 100644
+--- a/lib/package.c
++++ b/lib/package.c
+@@ -20,76 +20,72 @@
+ 
+ #include "debug.h"
+ 
++static struct taglate_s {
++    rpmTagVal stag;
++    rpmTagVal xtag;
++    rpm_count_t count;
++} const xlateTags[] = {
++    { RPMSIGTAG_SIZE, RPMTAG_SIGSIZE, 1 },
++    { RPMSIGTAG_PGP, RPMTAG_SIGPGP, 0 },
++    { RPMSIGTAG_MD5, RPMTAG_SIGMD5, 16 },
++    { RPMSIGTAG_GPG, RPMTAG_SIGGPG, 0 },
++    /* { RPMSIGTAG_PGP5, RPMTAG_SIGPGP5, INT32_MAX }, */
++    { RPMSIGTAG_PAYLOADSIZE, RPMTAG_ARCHIVESIZE, 1 },
++    { RPMSIGTAG_SHA1, RPMTAG_SHA1HEADER, 1 },
++    { RPMSIGTAG_SHA256, RPMTAG_SHA256HEADER, 1 },
++    { RPMSIGTAG_DSA, RPMTAG_DSAHEADER, 0 },
++    { RPMSIGTAG_RSA, RPMTAG_RSAHEADER, 0 },
++    { RPMSIGTAG_LONGSIZE, RPMTAG_LONGSIGSIZE, 1 },
++    { RPMSIGTAG_LONGARCHIVESIZE, RPMTAG_LONGARCHIVESIZE, 1 },
++    { 0, 0, 0 },
++};
++
+ /** \ingroup header
+  * Translate and merge legacy signature tags into header.
+  * @param h		header (dest)
+  * @param sigh		signature header (src)
++ * @return		failing tag number, 0 on success
+  */
+ static
+-void headerMergeLegacySigs(Header h, Header sigh)
++rpmTagVal headerMergeLegacySigs(Header h, Header sigh, char **emsg)
+ {
+-    HeaderIterator hi;
++    const struct taglate_s *xl;
+     struct rpmtd_s td;
+ 
+-    hi = headerInitIterator(sigh);
+-    for (; headerNext(hi, &td); rpmtdFreeData(&td))
+-    {
+-	switch (td.tag) {
+-	/* XXX Translate legacy signature tag values. */
+-	case RPMSIGTAG_SIZE:
+-	    td.tag = RPMTAG_SIGSIZE;
+-	    break;
+-	case RPMSIGTAG_PGP:
+-	    td.tag = RPMTAG_SIGPGP;
+-	    break;
+-	case RPMSIGTAG_MD5:
+-	    td.tag = RPMTAG_SIGMD5;
+-	    break;
+-	case RPMSIGTAG_GPG:
+-	    td.tag = RPMTAG_SIGGPG;
+-	    break;
+-	case RPMSIGTAG_PGP5:
+-	    td.tag = RPMTAG_SIGPGP5;
+-	    break;
+-	case RPMSIGTAG_PAYLOADSIZE:
+-	    td.tag = RPMTAG_ARCHIVESIZE;
+-	    break;
+-	case RPMSIGTAG_SHA1:
+-	case RPMSIGTAG_SHA256:
+-	case RPMSIGTAG_DSA:
+-	case RPMSIGTAG_RSA:
+-	default:
+-	    if (!(td.tag >= HEADER_SIGBASE && td.tag < HEADER_TAGBASE))
+-		continue;
+-	    break;
+-	}
+-	if (!headerIsEntry(h, td.tag)) {
+-	    switch (td.type) {
+-	    case RPM_NULL_TYPE:
+-		continue;
++    for (xl = xlateTags; xl->stag; xl++) {
++	/* There mustn't be one in the main header */
++	if (headerIsEntry(h, xl->xtag))
++	    goto exit;
++    }
++
++    rpmtdReset(&td);
++    for (xl = xlateTags; xl->stag; xl++) {
++	if (headerGet(sigh, xl->stag, &td, HEADERGET_RAW|HEADERGET_MINMEM)) {
++	    /* Translate legacy tags */
++	    if (xl->stag != xl->xtag)
++		td.tag = xl->xtag;
++	    /* Ensure type and tag size match expectations */
++	    if (td.type != rpmTagGetTagType(td.tag))
+ 		break;
+-	    case RPM_CHAR_TYPE:
+-	    case RPM_INT8_TYPE:
+-	    case RPM_INT16_TYPE:
+-	    case RPM_INT32_TYPE:
+-	    case RPM_INT64_TYPE:
+-		if (td.count != 1)
+-		    continue;
++	    if (td.count < 1 || td.count > 16 * 1024L * 1024L)
+ 		break;
+-	    case RPM_STRING_TYPE:
+-	    case RPM_BIN_TYPE:
+-		if (td.count >= 16*1024)
+-		    continue;
++	    if (xl->count && td.count != xl->count)
+ 		break;
+-	    case RPM_STRING_ARRAY_TYPE:
+-	    case RPM_I18NSTRING_TYPE:
+-		continue;
++	    if (!headerPut(h, &td, HEADERPUT_DEFAULT))
+ 		break;
+-	    }
+-	    (void) headerPut(h, &td, HEADERPUT_DEFAULT);
++	    /* note: this is idempotent and can be called multiple times */
++	    rpmtdFreeData(&td);
+ 	}
+     }
+-    headerFreeIterator(hi);
++    rpmtdFreeData(&td);
++
++exit:
++    if (xl->stag) {
++	rasprintf(emsg, "invalid signature tag %s (%d)",
++			rpmTagGetName(xl->xtag), xl->xtag);
++    }
++
++    return xl->stag;
+ }
+ 
+ /**
+@@ -337,7 +333,8 @@ rpmRC rpmReadPackageFile(rpmts ts, FD_t fd, const char * fn, Header * hdrp)
+ 		goto exit;
+ 
+ 	    /* Append (and remap) signature tags to the metadata. */
+-	    headerMergeLegacySigs(h, sigh);
++	    if (headerMergeLegacySigs(h, sigh, &msg))
++		goto exit;
+ 	    applyRetrofits(h);
+ 
+ 	    /* Bump reference count for return. */
+-- 
+2.30.2
+

--- a/Verify-lengths-in-hdrblobInit.patch
+++ b/Verify-lengths-in-hdrblobInit.patch
@@ -1,0 +1,106 @@
+From de83742cecefeca902ef7e415e08221f277211a2 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Mon, 15 Mar 2021 12:40:38 -0400
+Subject: [PATCH 2/2] Verify lengths in hdrblobInit()
+
+This is upstream commit 8f4b3c3cab8922a2022b9e47c71f1ecf906077ef.
+
+Fixes CVE-2021-20266
+---
+ lib/header.c | 48 +++++++++++++++++++++++++++++++-----------------
+ 1 file changed, 31 insertions(+), 17 deletions(-)
+
+diff --git a/lib/header.c b/lib/header.c
+index 5b09f83..0d19efd 100644
+--- a/lib/header.c
++++ b/lib/header.c
+@@ -11,6 +11,7 @@
+ #include "system.h"
+ #include <netdb.h>
+ #include <errno.h>
++#include <inttypes.h>
+ #include <rpm/rpmtypes.h>
+ #include <rpm/rpmstring.h>
+ #include "lib/header_internal.h"
+@@ -1890,6 +1891,25 @@ hdrblob hdrblobFree(hdrblob blob)
+     return NULL;
+ }
+ 
++static rpmRC hdrblobVerifyLengths(rpmTagVal regionTag, uint32_t il, uint32_t dl,
++				char **emsg) {
++    uint32_t il_max = HEADER_TAGS_MAX;
++    uint32_t dl_max = HEADER_DATA_MAX;
++    if (regionTag == RPMTAG_HEADERSIGNATURES) {
++	il_max = 32;
++	dl_max = 8192;
++    }
++    if (hdrchkRange(il_max, il)) {
++	rasprintf(emsg, _("hdr tags: BAD, no. of tags(%" PRIu32 ") out of range"), il);
++	return RPMRC_FAIL;
++    }
++    if (hdrchkRange(dl_max, dl)) {
++	rasprintf(emsg, _("hdr data: BAD, no. of bytes(%" PRIu32 ") out of range"), dl);
++	return RPMRC_FAIL;
++    }
++    return RPMRC_OK;
++}
++
+ rpmRC hdrblobRead(FD_t fd, int magic, int exact_size, rpmTagVal regionTag, hdrblob blob, char **emsg)
+ {
+     int32_t block[4];
+@@ -1902,13 +1922,6 @@ rpmRC hdrblobRead(FD_t fd, int magic, int exact_size, rpmTagVal regionTag, hdrbl
+     size_t nb;
+     rpmRC rc = RPMRC_FAIL;		/* assume failure */
+     int xx;
+-    int32_t il_max = HEADER_TAGS_MAX;
+-    int32_t dl_max = HEADER_DATA_MAX;
+-
+-    if (regionTag == RPMTAG_HEADERSIGNATURES) {
+-	il_max = 32;
+-	dl_max = 8192;
+-    }
+ 
+     memset(block, 0, sizeof(block));
+     if ((xx = Freadall(fd, bs, blen)) != blen) {
+@@ -1921,15 +1934,9 @@ rpmRC hdrblobRead(FD_t fd, int magic, int exact_size, rpmTagVal regionTag, hdrbl
+ 	goto exit;
+     }
+     il = ntohl(block[2]);
+-    if (hdrchkRange(il_max, il)) {
+-	rasprintf(emsg, _("hdr tags: BAD, no. of tags(%d) out of range"), il);
+-	goto exit;
+-    }
+     dl = ntohl(block[3]);
+-    if (hdrchkRange(dl_max, dl)) {
+-	rasprintf(emsg, _("hdr data: BAD, no. of bytes(%d) out of range"), dl);
++    if (hdrblobVerifyLengths(regionTag, il, dl, emsg))
+ 	goto exit;
+-    }
+ 
+     nb = (il * sizeof(struct entryInfo_s)) + dl;
+     uc = sizeof(il) + sizeof(dl) + nb;
+@@ -1973,11 +1980,18 @@ rpmRC hdrblobInit(const void *uh, size_t uc,
+ 		struct hdrblob_s *blob, char **emsg)
+ {
+     rpmRC rc = RPMRC_FAIL;
+-
+     memset(blob, 0, sizeof(*blob));
++    if (uc && uc < 8) {
++	rasprintf(emsg, _("hdr length: BAD"));
++	goto exit;
++    }
++
+     blob->ei = (int32_t *) uh; /* discards const */
+-    blob->il = ntohl(blob->ei[0]);
+-    blob->dl = ntohl(blob->ei[1]);
++    blob->il = ntohl((uint32_t)blob->ei[0]);
++    blob->dl = ntohl((uint32_t)blob->ei[1]);
++    if (hdrblobVerifyLengths(regionTag, blob->il, blob->dl, emsg))
++	goto exit;
++
+     blob->pe = (entryInfo) &(blob->ei[2]);
+     blob->pvlen = sizeof(blob->il) + sizeof(blob->dl) +
+ 		  (blob->il * sizeof(*blob->pe)) + blob->dl;
+-- 
+2.30.2
+

--- a/rpm.spec
+++ b/rpm.spec
@@ -71,6 +71,8 @@ Patch101: 0001-rpmfc-push-name-epoch-version-release-macro-before-i.patch
 Patch906: rpm-4.7.1-geode-i686.patch
 # Probably to be upstreamed in slightly different form
 Patch907: rpm-4.13.90-ldflags.patch
+# CVE patch
+Patch909: Fix-CVE-2021-20271-and-CVE-2021-3421.patch
 
 # Partially GPL/LGPL dual-licensed and some bits with BSD
 # SourceLicense: (GPLv2+ and LGPLv2+ with exceptions) and BSD 
@@ -340,7 +342,7 @@ Requires: rpm-libs%{_isa} = %{version}-%{release}
 Useful on legacy SysV init systems if you run rpm transactions with
 nice/ionice priorities. Should not be used on systemd systems.
 
-%endif # with plugins
+%endif
 
 %prep
 %autosetup -n %{name}-%{srcver} %{?with_int_bdb:-a 1} -p1
@@ -540,7 +542,7 @@ make check || cat tests/rpmtests.log
 
 %files plugin-prioreset
 %{_libdir}/rpm-plugins/prioreset.so
-%endif # with plugins
+%endif
 
 %files build-libs
 %{_libdir}/librpmbuild.so.*

--- a/rpm.spec
+++ b/rpm.spec
@@ -73,6 +73,7 @@ Patch906: rpm-4.7.1-geode-i686.patch
 Patch907: rpm-4.13.90-ldflags.patch
 # CVE patch
 Patch909: Fix-CVE-2021-20271-and-CVE-2021-3421.patch
+Patch910: Verify-lengths-in-hdrblobInit.patch
 
 # Partially GPL/LGPL dual-licensed and some bits with BSD
 # SourceLicense: (GPLv2+ and LGPLv2+ with exceptions) and BSD 


### PR DESCRIPTION
This fix is slightly more efficient than upstream’s.